### PR TITLE
Drop support for old syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Browser support can be seen here: http://caniuse.com/#search=flex-box
 - [`flex-shrink(value)`][flex-shrink]
 - [`flex-direction(value)`][flex-direction]`value` can be: *row*, *row-reverse*, *column* or *column-reverse*
 - [`flex-wrap(value)`][flex-wrap] Accepts the 3 options: *nowrap*, *wrap*, *wrap-reverse*
+- [`flex-flow(value)`][flex-flow] Shortcut for `flex-direction || flex-wrap`. Example: `flex-flow(row wrap)`
 - [`justify-content(value)`][justify-content] `value` can be: *start*, *end*, *center*, *space-bottom* or *space-around*
 - [`align-content(value)`][align-content] `value` can be the same options as for `justify-content(value)`
 - [`align-items(value)`][align-items] `value` can be: *start*, *end*, *stretch*, *center*, *baseline*

--- a/README.md
+++ b/README.md
@@ -6,15 +6,50 @@
 
 Just place the **flexbox.styl** file into your project, then import it in your stylus file with `@import 'flexbox'`  Each function tries to accept as many official values (according to the Flexbox standard), but does require some changes.
 
+## Browser Support
+
+Browser support can be seen here: http://caniuse.com/#search=flex-box
+
 ## Functions
 
-- `flexbox(value)` where value is either *flex*, or *inline-flex*.
-- `flex(size, grow, shrink, basis)` Each value except *grow* is optional.  *Size* is used for a width attribute (for legacy browsers).  To only set the grow value, use `flex(grow: 1)`.  The same format can be used to set any specific arguments.
-- `flex-direction(value)``value` can be: *row*, *row-reverse*, *column* or *column-reverse* - Function for Flexbox's **flex-direction**
-- `flex-wrap(value)` Accepts the 3 options: *nowrap*, *wrap*, *wrap-reverse* - Function for Flexbox's **flex-wrap**
-- `flex-justify(value)` `value` can be: *start*, *end*, *center*, *space-bottom* or *space-around* - Function for Flexbox's **justify-content**
-- `flex-content(value)` `value` can be the same options as for `flex-justify(value)` - Function for Flexbox's **align-content**
-- `flex-align(value)` `value` can be: *start*, *end*, *stretch*, *center*, *baseline* - Function for Flexbox's **align-items**
-- `flex-self(value)` accepts *start*, *end*, *auto*, *center*, *baseline*, *stretch* - Function for Flexbox's **align-self**
-- `flex-group(value)` accepts any positive number - Function for Flexbox's **order** attribute
-- `flex-firefox()` Helper function for legacy Firefox (where Flexboxes were treated as inline items).  Place it inside the firefox-only selector (`@-moz-document url-prefix()`).  See the **example.styl** file for an example.
+- [`flexbox(value)`][flexbox] where value is either *flex*, or *inline-flex*.
+- [`flex(value)`][flex] value represent the setting of basis, grow and shrink, example: `flex(25% 1 1)`
+- [`flex-basis(value)`][flex-basis]
+- [`flex-grow(value)`][flex-grow]
+- [`flex-shrink(value)`][flex-shrink]
+- [`flex-direction(value)`][flex-direction]`value` can be: *row*, *row-reverse*, *column* or *column-reverse*
+- [`flex-wrap(value)`][flex-wrap] Accepts the 3 options: *nowrap*, *wrap*, *wrap-reverse*
+- [`justify-content(value)`][justify-content] `value` can be: *start*, *end*, *center*, *space-bottom* or *space-around*
+- [`align-content(value)`][align-content] `value` can be the same options as for `justify-content(value)`
+- [`align-items(value)`][align-items] `value` can be: *start*, *end*, *stretch*, *center*, *baseline*
+- [`align-self(value)`][align-self] accepts *start*, *end*, *auto*, *center*, *baseline*, *stretch*
+- [`order(value)`][order] accepts any positive number
+
+## Support
+
+This code supports the following browsers:
+
+Spec | Prefixed | Tweener
+-----|----------|---------
+Opera 12.1+ | Safari 6.1+ | IE 10
+Chrome 29+ | iOS 7.1+ |
+Firefox 28+ (current - 1) | |
+Android Browser 4.4+ | |
+IE 11+ | |
+
+### Known bugs for IE 10 and 11
+
+Ref: https://connect.microsoft.com/IE/feedback/details/802625/min-height-and-flexbox-flex-direction-column-dont-work-together-in-ie-10-11-preview
+
+[flexbox]: https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Flexible_boxes
+[flex]: https://developer.mozilla.org/en-US/docs/Web/CSS/flex
+[flex-basis]: https://developer.mozilla.org/en-US/docs/Web/CSS/flex-basis
+[flex-grow]: https://developer.mozilla.org/en-US/docs/Web/CSS/flex-grow
+[flex-shrink]: https://developer.mozilla.org/en-US/docs/Web/CSS/flex-shrink
+[flex-direction]: https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction
+[flex-wrap]: https://developer.mozilla.org/en-US/docs/Web/CSS/flex-wrap
+[justify-content]: https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content
+[align-content]: https://developer.mozilla.org/en-US/docs/Web/CSS/align-content
+[align-items]: https://developer.mozilla.org/en-US/docs/Web/CSS/align-items
+[align-self]: https://developer.mozilla.org/en-US/docs/Web/CSS/align-self
+[order]: https://developer.mozilla.org/en-US/docs/Web/CSS/order

--- a/css/example.css
+++ b/css/example.css
@@ -1,73 +1,64 @@
-@media screen {
-  body header,
-  body footer,
-  body section {
-    display: -webkit-box;
-    display: -moz-box;
-    display: -ms-flexbox;
-    display: -webkit-flex;
-    display: flex;
-    -webkit-box-direction: normal;
-    -moz-box-direction: normal;
-    -webkit-box-orient: vertical;
-    -moz-box-orient: vertical;
-    -webkit-flex-direction: column;
-    -ms-flex-direction: column;
-    flex-direction: column;
-    -webkit-box-align: start;
-    -moz-box-align: start;
-    -webkit-align-items: flex-start;
-    -ms-flex-align: start;
-    align-items: flex-start;
-  }
-  body header,
-  body footer {
-    width: 100%;
-  }
-  body article {
-    width: 60%;
-  }
-  body aside,
-  body div.sidebar {
-    -webkit-box-flex: 1;
-    -moz-box-flex: 1;
-    width: 20%;
-    -webkit-flex: 1 0 auto;
-    -ms-flex: 1 0 auto;
-    flex: 1 0 auto;
-  }
-  body aside {
-    -webkit-box-ordinal-group: 1;
-    -moz-box-ordinal-group: 1;
-    -ms-flex-order: 1;
-    -webkit-order: 1;
-    order: 1;
-    display: none;
-  }
-  body div.sidebar {
-    -webkit-box-ordinal-group: 3;
-    -moz-box-ordinal-group: 3;
-    -ms-flex-order: 3;
-    -webkit-order: 3;
-    order: 3;
-  }
-  body article {
-    -webkit-box-ordinal-group: 2;
-    -moz-box-ordinal-group: 2;
-    -ms-flex-order: 2;
-    -webkit-order: 2;
-    order: 2;
-    display: none;
-  }
-  body footer p {
-    -webkit-align-self: stretch;
-    -ms-flex-item-align: stretch;
-    align-self: stretch;
-  }
-  @-moz-document url-prefix() {
-    body article {
-      width: 100%;
-      -moz-box-sizing: border-box;
-    }
-  }
+* {
+  box-sizing: border-box;
+}
+body {
+  max-width: 720px;
+  margin: 0 auto;
+}
+body header,
+body footer,
+body section {
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+body section {
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+body header,
+body footer {
+  -webkit-flex-basis: 100%;
+  -ms-flex-basis: 100%;
+  flex-basis: 100%;
+  background: #f7f7f7;
+}
+body article {
+  -webkit-flex-basis: 48%;
+  -ms-flex-basis: 48%;
+  flex-basis: 48%;
+  background: #f4ccf4;
+  height: 100%;
+}
+body aside,
+body div.sidebar {
+  -webkit-flex: 24% 0;
+  -ms-flex: 24% 0;
+  flex: 24% 0;
+  background: #e4e4e4;
+  height: 100%;
+}
+body aside {
+  -ms-flex-order: 1;
+  -webkit-order: 1;
+  order: 1;
+}
+body div.sidebar {
+  -ms-flex-order: 3;
+  -webkit-order: 3;
+  order: 3;
+}
+body article {
+  -ms-flex-order: 2;
+  -webkit-order: 2;
+  order: 2;
+}
+body footer p {
+  -webkit-flex-grow: 1;
+  -ms-flex-grow: 1;
+  flex-grow: 1;
 }

--- a/stylus/example.styl
+++ b/stylus/example.styl
@@ -1,29 +1,32 @@
 @import 'flexbox'
 
-@media screen
-    body
-        header,footer,section
-            flexbox(flex)
-            flex-direction(column)
-            flex-align(start)
-        header, footer
-            width: 100%
-        article
-            width: 60%
-        aside, div.sidebar
-            flex(20%, 1)
-
-        aside
-            flex-group(1)
-            display none
-        div.sidebar
-            flex-group(3)
-        article
-            flex-group(2)
-            display none
-        footer p
-            flex-self(stretch)
-
-    @-moz-document url-prefix()
-        body article
-            flex-firefox()
+*
+  box-sizing border-box
+body
+  max-width 720px
+  margin 0 auto
+  header,footer,section
+    flexbox(flex)
+    flex-align(start)
+  section
+    justify-content(space-between)
+    align-items(center)
+  header, footer
+    flex-basis(100%)
+    background #f7f7f7
+  article
+    flex-basis(48%)
+    background #f4ccf4
+    height 100%
+  aside, div.sidebar
+    flex(24% 0)
+    background #e4e4e4
+    height 100%
+  aside
+    order(1)
+  div.sidebar
+    order(3)
+  article
+    order(2)
+  footer p
+    flex-grow(1)

--- a/stylus/flexbox.styl
+++ b/stylus/flexbox.styl
@@ -1,139 +1,101 @@
 flexbox(value)
-    // Initializing a flexbox container
-    display -webkit-box      /* OLD - iOS 6-, Safari 3.1-6 */
-    display -moz-box         /* OLD - Firefox 19- (buggy but mostly works) */
-    if value == inline-flex
-        display -ms-inline-flexbox      /* TWEENER - IE 10 */
-        display -webkit-inline-flex     /* NEW - Chrome */
-        display value                   /* NEW, Spec - Opera 12.1, Firefox 20+ */
-    else if value == flex
-        display -ms-flexbox       /* TWEENER - IE 10 */
-        display -webkit-flex      /* NEW - Chrome */
-        display flex              /* NEW, Spec - Opera 12.1, Firefox 20+ */
+  if value == inline-flex
+    display -webkit-inline-flex
+    display -ms-inline-flexbox
+    display inline-flex
+  else if value == flex
+    display -webkit-flex
+    display -ms-flexbox
+    display flex
 
-flex(size = null, grow = 0, shrink = 0, basis = auto)
-    // For configuring the flex elements
-    -webkit-box-flex grow
-    -moz-box-flex grow
-    if size != null
-        width size
-    -webkit-flex grow shrink basis
-    -ms-flex grow shrink basis
-    flex grow shrink basis
+flex(value)
+  -webkit-flex value
+  -ms-flex value
+  flex value
+
+flex-basis(value)
+  -webkit-flex-basis value
+  -ms-flex-basis value
+  flex-basis value
+
+flex-grow(value)
+  -webkit-flex-grow value
+  -ms-flex-grow value
+  flex-grow value
+
+flex-shrink(value)
+  -webkit-flex-shrink value
+  -ms-flex-shrink value
+  flex-shrink value
 
 flex-direction(value)
-    // Implementation of flex-direction attributes.
-    if value == row
-        -webkit-box-direction normal
-        -moz-box-direction normal
-        -webkit-box-orient horizontal
-        -moz-box-orient horizontal
-    else if value == row-reverse
-        -webkit-box-direction reverse
-        -moz-box-direction reverse
-        -webkit-box-orient horizontal
-        -moz-box-orient horizontal
-    else if value == column
-        -webkit-box-direction normal
-        -moz-box-direction normal
-        -webkit-box-orient vertical
-        -moz-box-orient vertical
-    else if value == column-reverse
-        -webkit-box-direction reverse
-        -moz-box-direction reverse
-        -webkit-box-orient vertical
-        -moz-box-orient vertical
-    -webkit-flex-direction value
-    -ms-flex-direction value
-    flex-direction value
+  -webkit-flex-direction value
+  -ms-flex-direction value
+  flex-direction value
 
 flex-wrap(value)
-    // Implementation of the flex-wrap attribute.
-    -webkit-flex-wrap value
-    -ms-flex-wrap value
-    flex-wrap value
+  -webkit-flex-wrap value
+  -ms-flex-wrap value
+  flex-wrap value
 
-flex-justify(value)
-    // Implements the justify-content settings.
-    if value == start || value == end
-        -webkit-box-pack value
-        -moz-box-pack value
-        -webkit-justify-content flex-+value
-        -ms-flex-pack value
-        justify-content flex-+value
-    else if value == center
-        -webkit-box-pack value
-        -moz-box-pack value
-        -webkit-justify-content value
-        -ms-flex-pack value
-        justify-content value
-    else if value == space-between
-        -webkit-box-pack justify
-        -moz-box-pack justify
-        -webkit-justify-content value
-        -ms-flex-pack justify
-        justify-content value
-    else if value == space-around
-        -webkit-box-pack justify
-        -moz-box-pack justify
-        -webkit-justify-content value
-        -ms-flex-pack distribute
-        justify-content value
+justify-content(value)
+  if value == start || value == end
+    -webkit-justify-content flex-+value
+    -ms-flex-pack value
+    justify-content flex-+value
+  else if value == center
+    -webkit-justify-content value
+    -ms-flex-pack value
+    justify-content value
+  else if value == space-between
+    -webkit-justify-content value
+    -ms-flex-pack justify
+    justify-content value
+  else if value == space-around
+    -webkit-justify-content value
+    -ms-flex-pack distribute
+    justify-content value
 
-flex-content(value)
-    // Implements the align-content settings
-    if value == space-around
-        -webkit-align-content value
-        -ms-flex-line-pack distribute
-        align-content value
-    else if value == space-between
-        -webkit-align-content value
-        -ms-flex-line-pack justify
-        align-content value
-    else if value == end or value == start
-        -webkit-align-content flex-+value
-        -ms-flex-line-pack value
-        align-content flex-+value
-    else
-        -webkit-align-content value
-        -ms-flex-line-pack value
-        align-content value
+align-content(value)
+  if value == space-around
+    -webkit-align-content value
+    -ms-flex-line-pack distribute
+    align-content value
+  else if value == space-between
+    -webkit-align-content value
+    -ms-flex-line-pack justify
+    align-content value
+  else if value == end or value == start
+    -webkit-align-content flex-+value
+    -ms-flex-line-pack value
+    align-content flex-+value
+  else
+    -webkit-align-content value
+    -ms-flex-line-pack value
+    align-content value
 
-flex-align(value)
-    // Function for align-items
-    if value == start or value == end
-        -webkit-box-align value
-        -moz-box-align value
-        -webkit-align-items flex-+value
-        -ms-flex-align value
-        align-items flex-+value
-    else
-        -webkit-box-align value
-        -moz-box-align value
-        -webkit-align-items value
-        -ms-flex-align value
-        align-items value
+align-items(value)
+  if value == start or value == end
+    -webkit-align-items flex-+value
+    -ms-flex-align value
+    align-items flex-+value
+  else
+    -webkit-align-items value
+    -ms-flex-align value
+    align-items value
 
-flex-self(value)
-    // Function for aligning the flex elements (align-self)
-    if value == start or value == end
-        -webkit-align-self flex-+value
-        -ms-flex-item-align value
-        align-self flex-+value
-    else
-        -webkit-align-self value
-        -ms-flex-item-align value
-        align-self value
+align-self(value)
+  if value == start or value == end
+    -webkit-align-self flex-+value
+    -ms-flex-item-align value
+    align-self flex-+value
+  else
+    -webkit-align-self value
+    -ms-flex-item-align value
+    align-self value
 
-flex-group(value)
-    // Manages ordering of the flex elements within a container
-    -webkit-box-ordinal-group value
-    -moz-box-ordinal-group value
-    -ms-flex-order value
-    -webkit-order value
-    order value
+order(value)
+  -ms-flex-order value
+  -webkit-order value
+  order value
 
-flex-firefox()
-    // Helper to manage inline bugs in legacy Firefox
-    width 100%
-    -moz-box-sizing border-box

--- a/stylus/flexbox.styl
+++ b/stylus/flexbox.styl
@@ -38,6 +38,11 @@ flex-wrap(value)
   -ms-flex-wrap value
   flex-wrap value
 
+flex-flow(value)
+  -webkit-flex-flow value
+  -ms-flex-flow value
+  flex-flow value
+
 justify-content(value)
   if value == start || value == end
     -webkit-justify-content flex-+value


### PR DESCRIPTION
This PR drops all support for the old flexbox syntax, based on current browsers that support it.

It also gives some significant changes to the syntax to match the actual properties and gives references for all of them in the README file, instead of the styl file.

The example was also modified to exemplify better the using of `flexbox.styl`.
